### PR TITLE
fixed rails_admin_nested_set precompile

### DIFF
--- a/lib/rails_admin_nested_set/engine.rb
+++ b/lib/rails_admin_nested_set/engine.rb
@@ -1,7 +1,7 @@
 module RailsAdminNestedSet
   class Engine < ::Rails::Engine
 
-    initializer "RailsAdminNestedSet precompile hook" do |app|
+    initializer "RailsAdminNestedSet precompile hook", group: :all do |app|
       app.config.assets.precompile += %w(rails_admin/rails_admin_nested_set.js rails_admin/rails_admin_nested_set.css)
     end
 


### PR DESCRIPTION
Error Message:
Sprockets::Helpers::RailsHelper::AssetPaths::AssetNotPrecompiledError: rails_admin/rails_admin_nested_set.css isn't precompiled

Where:
rails_admin/main#nested_set
[GEM_ROOT]/gems/actionpack-3.2.17/lib/sprockets/helpers/rails_helper.rb, line 142
