### PR TITLE
Added scoping feature to match rails_admin index view

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,32 @@ In model:
         })
     end
 
+Add in your `config/initializers/rails_admin.rb` initializer the configuration:
+
+```ruby
+RailsAdmin.config do |config|
+  config.actions do
+    # root actions
+    dashboard                     # mandatory
+    # collection actions
+    index                         # mandatory
+    new
+    export
+    history_index
+    bulk_delete
+    # member actions
+    show
+    edit
+    delete
+    history_show
+    show_in_app
+
+    # Add the nested_set action for configured models
+    nested_set
+  end
+end
+```
+
 ## Contributing
 
 1. Fork it

--- a/README.md
+++ b/README.md
@@ -27,32 +27,7 @@ Or install it yourself as:
 
 ## Usage with rails_admin
 
-Add the nested_set action for each model or only for models you need
-
-    RailsAdmin.config do |config|
-      config.actions do
-        ......
-        nested_set do
-          visible do
-            %w(Page).include? bindings[:abstract_model].model_name
-          end
-        end
-      end
-    end
-
 In model:
-
-    acts_as_nested_set
-    rails_admin do
-        ...
-        nested_set({
-            max_depth: 1,
-            toggle_fields: [:enabled],
-            thumbnail_fields: [:image, :cover],
-            thumbnail_size: :thumb,
-            thumbnail_gem: :paperclip, # or :carrierwave
-        })
-    end
 
 Add in your `config/initializers/rails_admin.rb` initializer the configuration:
 
@@ -79,6 +54,18 @@ RailsAdmin.config do |config|
   end
 end
 ```
+
+    acts_as_nested_set
+    rails_admin do
+        ...
+        nested_set({
+            max_depth: 1,
+            toggle_fields: [:enabled],
+            thumbnail_fields: [:image, :cover],
+            thumbnail_size: :thumb,
+            thumbnail_gem: :paperclip, # or :carrierwave
+        })
+    end
 
 ## Contributing
 

--- a/app/views/rails_admin/main/nested_set.html.haml
+++ b/app/views/rails_admin/main/nested_set.html.haml
@@ -1,6 +1,6 @@
 = stylesheet_link_tag 'rails_admin/rails_admin_nested_set'
 = javascript_include_tag 'rails_admin/rails_admin_nested_set'
 
-.row-fluid
-  .span12#rails_admin_nestable
+.row
+  .col-md-12#rails_admin_nestable
     = rails_admin_nested_set @nodes

--- a/app/views/rails_admin/main/nested_set.html.haml
+++ b/app/views/rails_admin/main/nested_set.html.haml
@@ -1,6 +1,14 @@
 = stylesheet_link_tag 'rails_admin/rails_admin_nested_set'
 = javascript_include_tag 'rails_admin/rails_admin_nested_set'
 
+- unless @model_config.list.scopes.empty?
+  %br
+    %ul.nav.nav-tabs#scope_selector
+      - @model_config.list.scopes.each_with_index do |scope, index|
+        - scope = '_all' if scope.nil?
+        %li{class: "#{'active' if scope.to_s == params[:scope] || (params[:scope].blank? && index == 0)}"}
+          %a{href: nested_set_path(params.merge(scope: scope, page: nil)), class: 'pjax'}= I18n.t("admin.scopes.#{@abstract_model.to_param}.#{scope}", default: I18n.t("admin.scopes.#{scope}", default: scope.to_s.titleize))
+
 .row
   .col-md-12#rails_admin_nestable
     = rails_admin_nested_set @nodes

--- a/lib/rails_admin_nested_set/action.rb
+++ b/lib/rails_admin_nested_set/action.rb
@@ -53,7 +53,20 @@ module RailsAdmin
 
               render text: message
             else
-              @nodes = list_entries(@model_config, :index, nil, nil).sort { |a,b| a.lft <=> b.lft }
+              @nodes ||= list_entries
+
+              unless @model_config.list.scopes.empty?
+                if params[:scope].blank?
+                  unless @model_config.list.scopes.first.nil?
+                    @nodes = @nodes.send(@model_config.list.scopes.first)
+                  end
+                elsif @model_config.list.scopes.collect(&:to_s).include?(params[:scope])
+                  @nodes = @nodes.send(params[:scope].to_sym)
+                end
+              end
+
+              @nodes = @nodes.sort { |a,b| a.lft <=> b.lft }
+
               render action: @action.template_name
             end
           end

--- a/lib/rails_admin_nested_set/action.rb
+++ b/lib/rails_admin_nested_set/action.rb
@@ -4,6 +4,11 @@ module RailsAdmin
       class NestedSet < Base
         RailsAdmin::Config::Actions.register(self)
 
+        register_instance_option :visible? do
+          current_model = ::RailsAdmin::Config.model(bindings[:abstract_model])
+          current_model.nested_set
+        end
+
         # Is the action acting on the root level (Example: /admin/contact)
         register_instance_option :root? do
           false

--- a/lib/rails_admin_nested_set/helper.rb
+++ b/lib/rails_admin_nested_set/helper.rb
@@ -93,9 +93,6 @@ module RailsAdminNestedSet
     def thumbnail_size
       @nested_set_conf.options[:thumbnail_size]
     end
-    def scopes
-      @nested_set_conf.options[:scopes] || '0'
-    end
 
     def action_links(model)
       content_tag :ul, class: 'inline actions' do

--- a/lib/rails_admin_nested_set/helper.rb
+++ b/lib/rails_admin_nested_set/helper.rb
@@ -95,7 +95,7 @@ module RailsAdminNestedSet
     end
 
     def action_links(model)
-      content_tag :ul, class: 'inline actions' do
+      content_tag :ul, class: 'list-inline actions' do
         menu_for :member, @abstract_model, model, true
       end
     end

--- a/lib/rails_admin_nested_set/helper.rb
+++ b/lib/rails_admin_nested_set/helper.rb
@@ -48,7 +48,7 @@ module RailsAdminNestedSet
             content += extra_fields(node)
 
             content += content_tag(:div, action_links(node), class: 'pull-right links')
-            
+
             thumbnail_fields.each do |mth|
               if node.respond_to?(mth)
                 img = if paperclip?
@@ -92,6 +92,9 @@ module RailsAdminNestedSet
     end
     def thumbnail_size
       @nested_set_conf.options[:thumbnail_size]
+    end
+    def scopes
+      @nested_set_conf.options[:scopes] || '0'
     end
 
     def action_links(model)

--- a/rails_admin_nested_set.gemspec
+++ b/rails_admin_nested_set.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "rails_admin", '~> 1.0.0'
+  gem.add_dependency "rails_admin", '~> 0.6.8'
 end

--- a/rails_admin_nested_set.gemspec
+++ b/rails_admin_nested_set.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "rails_admin", '~> 0.6.6'
+  gem.add_dependency "rails_admin", '~> 0.6.8'
 end

--- a/rails_admin_nested_set.gemspec
+++ b/rails_admin_nested_set.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "rails_admin", '~> 0.6.8'
+  gem.add_dependency "rails_admin", '~> 1.0.0'
 end


### PR DESCRIPTION
This pull request is with respect to #6.

If the list view in rails_admin has [scopes](https://github.com/sferik/rails_admin/wiki/List), this added the tabs view to the sorting view provided by rails_admin_nested_set. E.g.

``` ruby
RailsAdmin.config do |config|
  config.model Team do
    list do
      scopes [:not_cart, :cart, nil]
    end
  end
end
```

Example screenshot:

![screen shot 2015-02-07 at 17 27 26](https://cloud.githubusercontent.com/assets/1147871/6093004/22eec8ce-aeef-11e4-8d35-e08ab7677c2c.png)
